### PR TITLE
feat: Add database seeders for Post model

### DIFF
--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -18,6 +18,8 @@ class PostFactory extends Factory
     {
         return [
             //
+            'user_id' => \App\Models\User::all()->random()->id,
+            'message' => fake()->paragraph,
         ];
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,12 +14,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // Seed database with 10 users
-        \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        $this->call([
+            UserSeeder::class,
+            PostSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -5,7 +5,7 @@ namespace Database\Seeders;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
-class PostSeeder extends Seeder
+class UserSeeder extends Seeder
 {
     /**
      * Run the database seeds.
@@ -14,7 +14,7 @@ class PostSeeder extends Seeder
      */
     public function run()
     {
-        // Seed database with 30 posts
-        \App\Models\Post::factory(30)->create();
+        // Seed database with 10 users
+        \App\Models\User::factory(10)->create();
     }
 }


### PR DESCRIPTION
Added database seeder for post model to ease testing process.
by running the ``` php artisan db:seed``` command, the database now programmatically creates 10 new user and 30 example posts 